### PR TITLE
Update pnpm-lock.yaml to fix production build

### DIFF
--- a/connect-react-demo/pnpm-lock.yaml
+++ b/connect-react-demo/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@pipedream/connect-react':
-        specifier: 1.3.0
-        version: 1.3.0(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.3.1
+        version: 1.3.1(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@pipedream/sdk':
         specifier: ^1.6.6
         version: 1.6.8
@@ -330,8 +330,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@pipedream/connect-react@1.3.0':
-    resolution: {integrity: sha512-KcqlDUA5SGmAdU/wMEU/7XBaMvvZZjygKk4N7WHzj7446fhu9OTdtQLOpDSjfWiL8dN13mjcuw6xDO0VPCVgSQ==}
+  '@pipedream/connect-react@1.3.1':
+    resolution: {integrity: sha512-gj2tEyinVdNfZ0ljCUCcNaAHiUyMrkJIFF+9pp82IjnS7/27IIt+NvwfonesTasDK3JQJwgg6hDtLY+Jv6TnwA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -2397,7 +2397,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@pipedream/connect-react@1.3.0(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@pipedream/connect-react@1.3.1(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@pipedream/sdk': 1.6.8
       '@tanstack/react-query': 5.80.7(react@18.3.1)
@@ -2913,13 +2913,13 @@ snapshots:
 
   '@types/hast@3.0.4':
     dependencies:
-      '@types/unist': 2.0.11
+      '@types/unist': 3.0.3
 
   '@types/json-schema@7.0.15': {}
 
   '@types/mdast@4.0.4':
     dependencies:
-      '@types/unist': 2.0.11
+      '@types/unist': 3.0.3
 
   '@types/ms@2.1.0': {}
 


### PR DESCRIPTION
Fixes lockfile sync issue where @pipedream/connect-react was at 1.3.0 in lockfile but 1.3.1 in package.json

🤖 Generated with [Claude Code](https://claude.ai/code)