### PR TITLE
Move actions.run, triggers.deploy, accounts.list to server actions

### DIFF
--- a/connect-react-demo/app/actions/backendClient.ts
+++ b/connect-react-demo/app/actions/backendClient.ts
@@ -2,6 +2,7 @@
 
 import { env } from "@/lib/env";
 import { backendClient } from "@/lib/backend-client";
+import type { RunActionOpts, DeployTriggerOpts } from "@pipedream/sdk";
 
 export type FetchTokenOpts = {
   externalUserId: string
@@ -137,6 +138,25 @@ export const getAccountCredentials = async (opts: GetAccountCredentialsOpts) => 
     console.error("Failed to get account credentials:", error)
     throw new Error(error.message || "Failed to get account credentials")
   }
+}
+
+export const runAction = async (opts: RunActionOpts) => {
+  const serverClient = backendClient()
+  return serverClient.actions.run(opts)
+}
+
+export const deployTrigger = async (opts: DeployTriggerOpts) => {
+  const serverClient = backendClient()
+  return serverClient.triggers.deploy(opts)
+}
+
+export const listAccounts = async (opts: { externalUserId: string; app?: string }) => {
+  const serverClient = backendClient()
+  const page = await serverClient.accounts.list({
+    externalUserId: opts.externalUserId,
+    ...(opts.app && { app: opts.app }),
+  })
+  return page.data
 }
 
 export const getProjectId = async () => env.PIPEDREAM_PROJECT_ID

--- a/connect-react-demo/app/components/DemoPanel.tsx
+++ b/connect-react-demo/app/components/DemoPanel.tsx
@@ -157,8 +157,8 @@ export const DemoPanel = () => {
 
       const method = selectedComponentType === "action" ? "actions.run" : "triggers.deploy"
       const request = selectedComponentType === "action"
-        ? { externalUserId, id: selectedComponentKey, configuredProps, dynamicPropsId, ...(needsStash && { stashId: "" as const }) }
-        : { externalUserId, id: selectedComponentKey, configuredProps, webhookUrl, dynamicPropsId }
+        ? { externalUserId, id: selectedComponentKey, configuredProps, ...(dynamicPropsId && { dynamicPropsId }), ...(needsStash && { stashId: "" as const }) }
+        : { externalUserId, id: selectedComponentKey, configuredProps, ...(webhookUrl && { webhookUrl }), ...(dynamicPropsId && { dynamicPropsId }) }
 
       const startTime = Date.now()
       const callId = addCall({ method, timestamp: new Date(), request, status: "pending" })

--- a/connect-react-demo/app/components/DemoPanel.tsx
+++ b/connect-react-demo/app/components/DemoPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { ComponentFormContainer, CustomizeProvider, useFrontendClient, useCustomize, useAccounts, type FormContext } from "@pipedream/connect-react"
+import { ComponentFormContainer, CustomizeProvider, useFrontendClient, useCustomize, type FormContext } from "@pipedream/connect-react"
 import type { ConfigurableProps, DynamicProps, App } from "@pipedream/sdk"
 import { useAppState } from "@/lib/app-state"
 import { isValidUrl } from "@/lib/utils"
@@ -7,6 +7,9 @@ import { PageSkeleton } from "./PageSkeleton"
 import { TerminalCollapsible } from "./TerminalCollapsible"
 import { SDKError } from "@/lib/types/pipedream"
 import { ProxyRequestBuilder } from "./ProxyRequestBuilder"
+import { useServerAccounts } from "@/lib/hooks/use-server-accounts"
+import { useSDKLogger } from "@/lib/sdk-logger"
+import { runAction, deployTrigger } from "@/app/actions/backendClient"
 
 // Separate component that uses useCustomize (must be inside CustomizeProvider)
 function ProxyConnectFlow({
@@ -29,17 +32,11 @@ function ProxyConnectFlow({
   const { theme } = useCustomize()
 
   // Fetch accounts for the selected app
-  const { accounts, isLoading: isLoadingAccounts, refetch: refetchAccounts } = useAccounts(
-    {
-      external_user_id: externalUserId,
-      app: selectedApp?.nameSlug,
-    },
-    {
-      useQueryOpts: {
-        enabled: !!selectedApp,
-      },
-    }
-  )
+  const { accounts, isLoading: isLoadingAccounts, refetch: refetchAccounts } = useServerAccounts({
+    externalUserId,
+    app: selectedApp?.nameSlug,
+    enabled: !!selectedApp,
+  })
 
   const connectNewAccount = async () => {
     if (!selectedApp) return
@@ -104,6 +101,7 @@ export const DemoPanel = () => {
     setEditableExternalUserId,
   } = useAppState()
 
+  const { addCall, updateCall } = useSDKLogger()
   const [dynamicPropsId, setDynamicPropsId] = useState<string | undefined>()
   const [sdkErrors, setSdkErrors] = useState<SDKError | undefined>()
 
@@ -157,27 +155,34 @@ export const DemoPanel = () => {
       // Check if component requires stash for file handling
       const needsStash = ctx.component.stash === "required" || ctx.component.stash === "optional"
 
-      const data = selectedComponentType === "action"
-        ? await frontendClient.actions.run({
-          externalUserId,
-          id: selectedComponentKey,
-          configuredProps,
-          dynamicPropsId,
-          ...(needsStash && { stashId: "" })  // Add stashId if component uses file stash
-        })
-        : await frontendClient.triggers.deploy({
-          externalUserId,
-          id: selectedComponentKey,
-          configuredProps,
-          webhookUrl,
-          dynamicPropsId,
-        })
+      const method = selectedComponentType === "action" ? "actions.run" : "triggers.deploy"
+      const request = selectedComponentType === "action"
+        ? { externalUserId, id: selectedComponentKey, configuredProps, dynamicPropsId, ...(needsStash && { stashId: "" as const }) }
+        : { externalUserId, id: selectedComponentKey, configuredProps, webhookUrl, dynamicPropsId }
 
-      React.startTransition(() => {
-        setSdkErrors(undefined)
-        setActionRunOutput(data)
-        setWebhookUrlValidationAttempted(false) // Reset validation state on successful submission
-      })
+      const startTime = Date.now()
+      const callId = addCall({ method, timestamp: new Date(), request, status: "pending" })
+
+      try {
+        const data = selectedComponentType === "action"
+          ? await runAction(request)
+          : await deployTrigger(request)
+
+        updateCall(callId, { response: data, status: "success", duration: Date.now() - startTime })
+
+        React.startTransition(() => {
+          setSdkErrors(undefined)
+          setActionRunOutput(data)
+          setWebhookUrlValidationAttempted(false) // Reset validation state on successful submission
+        })
+      } catch (error) {
+        updateCall(callId, {
+          error: error instanceof Error ? { message: error.message } : error,
+          status: "error",
+          duration: Date.now() - startTime,
+        })
+        throw error
+      }
     } catch (error) {
       React.startTransition(() => {
         setSdkErrors(error as SDKError)

--- a/connect-react-demo/app/file-picker-sharepoint/page.tsx
+++ b/connect-react-demo/app/file-picker-sharepoint/page.tsx
@@ -4,8 +4,8 @@ import { useState, useMemo, useRef, useEffect, useCallback } from "react";
 import { useStableUuid } from "@/lib/stable-uuid";
 import {
   FrontendClientProvider,
-  useAccounts,
 } from "@pipedream/connect-react";
+import { useServerAccounts } from "@/lib/hooks/use-server-accounts";
 import { createFrontendClient } from "@pipedream/sdk/browser";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { getAccountCredentials } from "../actions/backendClient";
@@ -174,10 +174,7 @@ function AccountSelector({
   onConnectNew: () => Promise<void>;
   app?: string;
 }) {
-  const { accounts, isLoading, refetch } = useAccounts({
-    app,
-    external_user_id: externalUserId,
-  });
+  const { accounts, isLoading, refetch } = useServerAccounts({ app, externalUserId });
 
   const handleConnectNew = async () => {
     await onConnectNew();

--- a/connect-react-demo/app/file-picker/page.tsx
+++ b/connect-react-demo/app/file-picker/page.tsx
@@ -6,12 +6,12 @@ import {
   FrontendClientProvider,
   CustomizeProvider,
   ConfigureFilePickerModal,
-  useAccounts,
   type FilePickerItem,
 } from "@pipedream/connect-react";
+import { useServerAccounts } from "@/lib/hooks/use-server-accounts";
 import { createFrontendClient } from "@pipedream/sdk/browser";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { getAccountCredentials, getProjectId } from "../actions/backendClient";
+import { getAccountCredentials, getProjectId, runAction, deployTrigger } from "../actions/backendClient";
 import { queryClient, deferredTokenCallback, createClient } from "@/lib/frontend-client";
 
 // ============================================
@@ -200,10 +200,7 @@ function AccountSelector({
   onConnectNew: () => Promise<void>;
   app?: string;
 }) {
-  const { accounts, isLoading, refetch } = useAccounts({
-    app,
-    external_user_id: externalUserId,
-  });
+  const { accounts, isLoading, refetch } = useServerAccounts({ app, externalUserId });
 
   const handleConnectNew = async () => {
     await onConnectNew();
@@ -370,7 +367,7 @@ function ConfigureFilePickerDemo({ externalUserId }: { externalUserId: string })
       setIsLoadingAction(true);
       setActionResult(null);
       try {
-        const response = await client.actions.run({
+        const response = await runAction({
           id: "sharepoint_admin-retrieve-file-metadata",
           externalUserId,
           configuredProps: { ...props, fileIds: buildFileOrFolderIds(items) } as Record<string, unknown>,
@@ -414,7 +411,7 @@ function ConfigureFilePickerDemo({ externalUserId }: { externalUserId: string })
     try {
       // Map fileOrFolderIds to fileIds for download-files action
       const { fileOrFolderIds, ...otherProps } = configuredProps;
-      const response = await client.actions.run({
+      const response = await runAction({
         id: "sharepoint_admin-download-files",
         externalUserId,
         configuredProps: { ...otherProps, fileIds: getFileIds() } as Record<string, unknown>,
@@ -443,7 +440,7 @@ function ConfigureFilePickerDemo({ externalUserId }: { externalUserId: string })
       // Map fileOrFolderIds to fileIds for the trigger
       const { fileOrFolderIds, ...otherProps } = configuredProps;
 
-      const response = await client.triggers.deploy({
+      const response = await deployTrigger({
         id: "sharepoint_admin-updated-file-instant",
         externalUserId,
         webhookUrl: webhookUri,
@@ -962,9 +959,9 @@ function FilePickerLinkGenerator({ externalUserId }: { externalUserId: string })
   const [loading, setLoading] = useState(false);
   const [copied, setCopied] = useState(false);
 
-  const { accounts, isLoading: accountsLoading } = useAccounts({
+  const { accounts, isLoading: accountsLoading } = useServerAccounts({
     app: "sharepoint_admin",
-    external_user_id: externalUserId,
+    externalUserId,
   });
 
   const handleGenerate = async () => {

--- a/connect-react-demo/lib/app-state.tsx
+++ b/connect-react-demo/lib/app-state.tsx
@@ -114,9 +114,9 @@ const useAppStateProviderValue = () => {
   }
 
   // Use useApp when we have a URL parameter, otherwise let SelectApp manage its own state
-  const { app: fetchedApp } = selectedAppSlug && externalUserId
-    ? useApp(selectedAppSlug)
-    : {}
+  const { app: fetchedApp } = useApp(selectedAppSlug || "", {
+    useQueryOpts: { enabled: !!(selectedAppSlug && externalUserId) },
+  })
   const selectedApp = fetchedApp || undefined
 
   const selectedComponentType: ComponentType = queryParams.type as ComponentType || ComponentType.Action
@@ -126,17 +126,17 @@ const useAppStateProviderValue = () => {
   const [webhookUrl, setWebhookUrl] = useState<string>("")
   const [webhookUrlValidationAttempted, setWebhookUrlValidationAttempted] = useState<boolean>(false)
 
-  // Fetch components for the selected app to auto-select the first one
-  const { components } = selectedComponentType !== "proxy"
-    ? useComponents({
-        app: selectedAppSlug,
-        componentType: selectedComponentType,
-        registry: "all",
-        limit: 1,
-      })
-    : { components: [] }
+  // Fetch components for the selected app to auto-select the first one.
+  // Always call unconditionally (Rules of Hooks). When type is "proxy", the
+  // result is ignored below so no harm from the extra fetch.
+  const { components } = useComponents({
+    app: selectedAppSlug,
+    componentType: selectedComponentType !== "proxy" ? selectedComponentType : undefined,
+    registry: "all",
+    limit: 1,
+  })
 
-  const defaultComponentKey = queryParams.app
+  const defaultComponentKey = queryParams.app && selectedComponentType !== "proxy"
     ? components?.[0]?.key
     : "slack_v2-send-message-to-channel"
   const selectedComponentKey = queryParams.component || defaultComponentKey

--- a/connect-react-demo/lib/hooks/use-server-accounts.ts
+++ b/connect-react-demo/lib/hooks/use-server-accounts.ts
@@ -1,0 +1,46 @@
+"use client"
+
+import { useState, useEffect, useCallback, useContext } from "react"
+import type { Account } from "@pipedream/sdk"
+import { listAccounts } from "@/app/actions/backendClient"
+import { SDKLoggerContext } from "@/lib/sdk-logger"
+
+type Opts = {
+  externalUserId: string
+  app?: string
+  enabled?: boolean
+}
+
+export function useServerAccounts({ externalUserId, app, enabled = true }: Opts) {
+  const [accounts, setAccounts] = useState<Account[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const logger = useContext(SDKLoggerContext) // undefined outside SDKLoggerProvider — that's fine
+
+  const refetch = useCallback(async () => {
+    if (!enabled || !externalUserId) return
+    setIsLoading(true)
+
+    const request = { externalUserId, ...(app && { app }) }
+    const startTime = Date.now()
+    const callId = logger?.addCall({ method: "accounts.list", timestamp: new Date(), request, status: "pending" })
+
+    try {
+      const data = await listAccounts(request)
+      setAccounts(data)
+      if (callId) logger?.updateCall(callId, { response: data, status: "success", duration: Date.now() - startTime })
+    } catch (error) {
+      setAccounts([])
+      if (callId) logger?.updateCall(callId, {
+        error: error instanceof Error ? { message: error.message } : error,
+        status: "error",
+        duration: Date.now() - startTime,
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }, [externalUserId, app, enabled, logger])
+
+  useEffect(() => { refetch() }, [refetch])
+
+  return { accounts, isLoading, refetch }
+}

--- a/connect-react-demo/lib/sdk-logger.tsx
+++ b/connect-react-demo/lib/sdk-logger.tsx
@@ -24,7 +24,7 @@ interface SDKLoggerContextType {
   getPendingCallCount: () => number
 }
 
-const SDKLoggerContext = createContext<SDKLoggerContextType | undefined>(undefined)
+export const SDKLoggerContext = createContext<SDKLoggerContextType | undefined>(undefined)
 
 // Limit the number of calls we keep in memory
 const MAX_CALLS = 100


### PR DESCRIPTION
## Summary

- Adds `runAction`, `deployTrigger`, and `listAccounts` server actions to `backendClient.ts`, using the server-side `PipedreamClient` (clientId/clientSecret) instead of the browser token
- Creates `useServerAccounts` hook to replace `useAccounts` from connect-react — logs to the Debug tab when inside `SDKLoggerProvider`, silently skips logging elsewhere
- Updates `DemoPanel` to call server actions for `actions.run` and `triggers.deploy`, with manual `addCall`/`updateCall` instrumentation so the Debug tab continues to show these calls
- Updates `file-picker` and `file-picker-sharepoint` pages to use server actions
- Fixes pre-existing Rules of Hooks violations in `app-state.tsx` (`useApp` and `useComponents` were called conditionally, which caused a crash when switching to the Proxy tab)

## What stays in the browser
- `connectAccount()` — OAuth iframe flow, must be browser
- `ComponentFormContainer` internals (prop config, reload props, etc.) — controlled by connect-react

## Test plan

- [ ] Run action in the main demo — verify Debug tab shows `actions.run` entry with request/response
- [ ] Deploy trigger in the main demo — verify Debug tab shows `triggers.deploy` entry
- [ ] Switch to Proxy tab — verify no React hooks-order error, `accounts.list` appears in Debug tab
- [ ] Connect a new account via Proxy tab — verify accounts list refreshes
- [ ] Verify `/file-picker` page still loads accounts and can run actions/deploy triggers
- [ ] Verify `/file-picker-sharepoint` page still loads accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)