### PR TITLE
Add 30s timeout to proxy requests (DJ-3996)

### DIFF
--- a/connect-react-demo/app/actions/backendClient.ts
+++ b/connect-react-demo/app/actions/backendClient.ts
@@ -44,8 +44,11 @@ export const fetchToken = async (opts: FetchTokenOpts) => {
   return resp
 }
 
+const PROXY_TIMEOUT_SECONDS = 30
+
 const _proxyRequest = async (opts: ProxyRequestOpts) => {
   const serverClient = backendClient()
+  const requestOptions = { timeoutInSeconds: PROXY_TIMEOUT_SECONDS }
 
   try {
     const baseRequest = {
@@ -60,28 +63,28 @@ const _proxyRequest = async (opts: ProxyRequestOpts) => {
 
     switch (method) {
       case "GET":
-        resp = await serverClient.proxy.get(baseRequest)
+        resp = await serverClient.proxy.get(baseRequest, requestOptions)
         break
       case "POST":
         resp = await serverClient.proxy.post({
           ...baseRequest,
           body: opts.data,
-        })
+        }, requestOptions)
         break
       case "PUT":
         resp = await serverClient.proxy.put({
           ...baseRequest,
           body: opts.data,
-        })
+        }, requestOptions)
         break
       case "DELETE":
-        resp = await serverClient.proxy.delete(baseRequest)
+        resp = await serverClient.proxy.delete(baseRequest, requestOptions)
         break
       case "PATCH":
         resp = await serverClient.proxy.patch({
           ...baseRequest,
           body: opts.data,
-        })
+        }, requestOptions)
         break
       default:
         throw new Error(`Unsupported HTTP method: ${method}`)


### PR DESCRIPTION
## Summary

- Adds a 30-second timeout to all proxy requests in the Vercel demo app (`connect-react-demo`) to prevent requests from hanging indefinitely
- Uses the SDK's `timeoutInSeconds` option on all five HTTP methods (GET, POST, PUT, DELETE, PATCH)

## Changes

- `connect-react-demo/app/actions/backendClient.ts`: Add `PROXY_TIMEOUT_SECONDS = 30` constant and pass `{ timeoutInSeconds: PROXY_TIMEOUT_SECONDS }` as the second argument to all `serverClient.proxy.*` calls

## Test plan

- [ ] Make a proxy request in the demo app and verify it completes normally
- [ ] Verify that a request to a slow/unresponsive endpoint times out after ~30 seconds rather than hanging

Fixes DJ-3996

🤖 Generated with [Claude Code](https://claude.com/claude-code)