### PR TITLE
Revert: move actions.run and triggers.deploy back to server client

### DIFF
--- a/connect-react-demo/app/components/DemoPanel.tsx
+++ b/connect-react-demo/app/components/DemoPanel.tsx
@@ -9,6 +9,7 @@ import { SDKError } from "@/lib/types/pipedream"
 import { ProxyRequestBuilder } from "./ProxyRequestBuilder"
 import { useServerAccounts } from "@/lib/hooks/use-server-accounts"
 import { useSDKLogger } from "@/lib/sdk-logger"
+import { runAction, deployTrigger } from "@/app/actions/backendClient"
 
 // Separate component that uses useCustomize (must be inside CustomizeProvider)
 function ProxyConnectFlow({
@@ -164,8 +165,8 @@ export const DemoPanel = () => {
 
       try {
         const data = selectedComponentType === "action"
-          ? await frontendClient.actions.run(request)
-          : await frontendClient.triggers.deploy(request)
+          ? await runAction(request)
+          : await deployTrigger(request)
 
         updateCall(callId, { response: data, status: "success", duration: Date.now() - startTime })
 


### PR DESCRIPTION
## Summary
- Reverts 3684eba, which moved `actions.run` and `triggers.deploy` in `DemoPanel` from the server-side `backendClient` (via `runAction` / `deployTrigger` server actions) to the browser-side `frontendClient`.
- These calls now go back through the server action path in `app/actions/backendClient.ts`.

## Test plan
- [ ] Run the demo locally and submit an action — verify it executes via the server action (`runAction`) and the response renders in the UI.
- [ ] Deploy a trigger with a valid webhook URL — verify it succeeds via `deployTrigger` and the response renders.
- [ ] Confirm errors still surface in the SDK logger/terminal as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)