### PR TITLE
Return errors from server actions instead of throwing

### DIFF
--- a/connect-react-demo/app/actions/backendClient.ts
+++ b/connect-react-demo/app/actions/backendClient.ts
@@ -18,6 +18,16 @@ export type ProxyRequestOpts = {
   headers?: Record<string, string>
 }
 
+export type ActionError = {
+  message: string
+  status?: number
+  data?: any
+}
+
+export type ActionResult<T> =
+  | { data: T; error?: undefined }
+  | { data?: undefined; error: ActionError }
+
 const allowedOrigins = ([
   process.env.VERCEL_URL,
   process.env.VERCEL_BRANCH_URL,
@@ -44,20 +54,20 @@ export const fetchToken = async (opts: FetchTokenOpts) => {
   return resp
 }
 
-const _proxyRequest = async (opts: ProxyRequestOpts) => {
+const _proxyRequest = async (opts: ProxyRequestOpts): Promise<ActionResult<any>> => {
   const serverClient = backendClient()
 
+  const baseRequest = {
+    url: opts.url,
+    externalUserId: opts.externalUserId,
+    accountId: opts.accountId,
+    ...(opts.headers && { headers: opts.headers }),
+  }
+
+  const method = opts.method.toUpperCase()
+
   try {
-    const baseRequest = {
-      url: opts.url,
-      externalUserId: opts.externalUserId,
-      accountId: opts.accountId,
-      ...(opts.headers && { headers: opts.headers }),
-    }
-
     let resp
-    const method = opts.method.toUpperCase()
-
     switch (method) {
       case "GET":
         resp = await serverClient.proxy.get(baseRequest)
@@ -84,21 +94,19 @@ const _proxyRequest = async (opts: ProxyRequestOpts) => {
         })
         break
       default:
-        throw new Error(`Unsupported HTTP method: ${method}`)
+        return { error: { message: `Unsupported HTTP method: ${method}` } }
     }
 
-    return {
-      data: resp,
-    }
+    return { data: resp }
   } catch (error: any) {
-    // Create a proper Error object to preserve stack trace
-    const proxyError = new Error(error.message || 'Proxy request failed') as Error & {
-      status?: number
-      data?: any
+    console.error("[proxy] failed", { message: error.message, status: error.statusCode, body: error.body })
+    return {
+      error: {
+        message: error.message || "Proxy request failed",
+        status: error.statusCode,
+        data: error.body,
+      },
     }
-    proxyError.status = error.statusCode
-    proxyError.data = error.body
-    throw proxyError
   }
 }
 
@@ -153,7 +161,7 @@ function toSerializableResult<T>(prefix: string, value: T): T {
   }
 }
 
-function toSerializableError(prefix: string, error: any): Error {
+function toActionError(prefix: string, error: any): ActionError {
   const status = error.statusCode ?? error.status
   const body = error.body ?? error.data
   console.error(`[${prefix}] failed`, { status, body, message: error.message })
@@ -167,30 +175,34 @@ function toSerializableError(prefix: string, error: any): Error {
   } else {
     detail = JSON.stringify(body)
   }
-  return new Error(`${prefix} failed (HTTP ${status ?? "unknown"}): ${detail}`)
+  return {
+    message: `${prefix} failed (HTTP ${status ?? "unknown"}): ${detail}`,
+    status,
+    data: body,
+  }
 }
 
-export const runAction = async (opts: RunActionOpts) => {
+export const runAction = async (opts: RunActionOpts): Promise<ActionResult<any>> => {
   const serverClient = backendClient()
   console.log("[actions.run] called", { id: opts.id, externalUserId: opts.externalUserId })
   try {
-    return toSerializableResult("actions.run", await serverClient.actions.run(opts))
+    return { data: toSerializableResult("actions.run", await serverClient.actions.run(opts)) }
   } catch (error: any) {
-    throw toSerializableError("actions.run", error)
+    return { error: toActionError("actions.run", error) }
   }
 }
 
-export const deployTrigger = async (opts: DeployTriggerOpts) => {
+export const deployTrigger = async (opts: DeployTriggerOpts): Promise<ActionResult<any>> => {
   const serverClient = backendClient()
   console.log("[triggers.deploy] called", { externalUserId: opts.externalUserId })
   try {
-    return toSerializableResult("triggers.deploy", await serverClient.triggers.deploy(opts))
+    return { data: toSerializableResult("triggers.deploy", await serverClient.triggers.deploy(opts)) }
   } catch (error: any) {
-    throw toSerializableError("triggers.deploy", error)
+    return { error: toActionError("triggers.deploy", error) }
   }
 }
 
-export const listAccounts = async (opts: { externalUserId: string; app?: string }) => {
+export const listAccounts = async (opts: { externalUserId: string; app?: string }): Promise<ActionResult<any>> => {
   const serverClient = backendClient()
   console.log("[accounts.list] called", { externalUserId: opts.externalUserId, app: opts.app })
   try {
@@ -198,9 +210,9 @@ export const listAccounts = async (opts: { externalUserId: string; app?: string 
       externalUserId: opts.externalUserId,
       ...(opts.app && { app: opts.app }),
     })
-    return toSerializableResult("accounts.list", page.data)
+    return { data: toSerializableResult("accounts.list", page.data) }
   } catch (error: any) {
-    throw toSerializableError("accounts.list", error)
+    return { error: toActionError("accounts.list", error) }
   }
 }
 

--- a/connect-react-demo/app/components/DemoPanel.tsx
+++ b/connect-react-demo/app/components/DemoPanel.tsx
@@ -151,44 +151,41 @@ export const DemoPanel = () => {
       }
     }
 
-    try {
-      // Check if component requires stash for file handling
-      const needsStash = ctx.component.stash === "required" || ctx.component.stash === "optional"
+    // Check if component requires stash for file handling
+    const needsStash = ctx.component.stash === "required" || ctx.component.stash === "optional"
 
-      const method = selectedComponentType === "action" ? "actions.run" : "triggers.deploy"
-      const request = selectedComponentType === "action"
-        ? { externalUserId, id: selectedComponentKey, configuredProps, ...(dynamicPropsId && { dynamicPropsId }), ...(needsStash && { stashId: "" as const }) }
-        : { externalUserId, id: selectedComponentKey, configuredProps, ...(webhookUrl && { webhookUrl }), ...(dynamicPropsId && { dynamicPropsId }) }
+    const method = selectedComponentType === "action" ? "actions.run" : "triggers.deploy"
+    const request = selectedComponentType === "action"
+      ? { externalUserId, id: selectedComponentKey, configuredProps, ...(dynamicPropsId && { dynamicPropsId }), ...(needsStash && { stashId: "" as const }) }
+      : { externalUserId, id: selectedComponentKey, configuredProps, ...(webhookUrl && { webhookUrl }), ...(dynamicPropsId && { dynamicPropsId }) }
 
-      const startTime = Date.now()
-      const callId = addCall({ method, timestamp: new Date(), request, status: "pending" })
+    const startTime = Date.now()
+    const callId = addCall({ method, timestamp: new Date(), request, status: "pending" })
 
-      try {
-        const data = selectedComponentType === "action"
-          ? await runAction(request)
-          : await deployTrigger(request)
+    const result = selectedComponentType === "action"
+      ? await runAction(request)
+      : await deployTrigger(request)
 
-        updateCall(callId, { response: data, status: "success", duration: Date.now() - startTime })
-
-        React.startTransition(() => {
-          setSdkErrors(undefined)
-          setActionRunOutput(data)
-          setWebhookUrlValidationAttempted(false) // Reset validation state on successful submission
-        })
-      } catch (error) {
-        updateCall(callId, {
-          error: error instanceof Error ? { message: error.message } : error,
-          status: "error",
-          duration: Date.now() - startTime,
-        })
-        throw error
-      }
-    } catch (error) {
+    if (result.error) {
+      updateCall(callId, {
+        error: { message: result.error.message },
+        status: "error",
+        duration: Date.now() - startTime,
+      })
       React.startTransition(() => {
-        setSdkErrors(error as SDKError)
+        setSdkErrors(new Error(result.error!.message) as SDKError)
         setActionRunOutput(undefined)
       })
+      return
     }
+
+    updateCall(callId, { response: result.data, status: "success", duration: Date.now() - startTime })
+
+    React.startTransition(() => {
+      setSdkErrors(undefined)
+      setActionRunOutput(result.data)
+      setWebhookUrlValidationAttempted(false) // Reset validation state on successful submission
+    })
   }
 
   return (

--- a/connect-react-demo/app/components/ProxyRequestBuilder.tsx
+++ b/connect-react-demo/app/components/ProxyRequestBuilder.tsx
@@ -149,42 +149,29 @@ export function ProxyRequestBuilder({
 
     const startTime = Date.now()
 
-    try {
-      // Make the actual proxy request using server action
-      const proxyResponse = await proxyRequest(requestObject)
+    const proxyResponse = await proxyRequest(requestObject)
 
-      // Update SDK debugger with success
+    if (proxyResponse.error) {
+      const { message, status, data } = proxyResponse.error
+      updateCall(callId, {
+        error: { message, status, data },
+        status: "error",
+        duration: Date.now() - startTime,
+      })
+
+      setError(message)
+      setActionRunOutput({ error: message, status, data })
+    } else {
       updateCall(callId, {
         response: proxyResponse.data,
         status: "success",
-        duration: Date.now() - startTime
+        duration: Date.now() - startTime,
       })
 
-      // Send response data to output
       setActionRunOutput(proxyResponse.data)
-    } catch (err: any) {
-      // Update SDK debugger with error
-      updateCall(callId, {
-        error: {
-          message: err?.message || "Request failed",
-          status: err?.status,
-          data: err?.data,
-        },
-        status: "error",
-        duration: Date.now() - startTime
-      })
-
-      setError(err?.message || "Request failed")
-
-      // Show error response data in output
-      setActionRunOutput({
-        error: err?.message || "Request failed",
-        status: err?.status,
-        data: err?.data,
-      })
-    } finally {
-      setIsLoading(false)
     }
+
+    setIsLoading(false)
   }
 
   const showBodyField = ["POST", "PUT", "PATCH"].includes(proxyMethod)

--- a/connect-react-demo/app/file-picker/page.tsx
+++ b/connect-react-demo/app/file-picker/page.tsx
@@ -366,19 +366,18 @@ function ConfigureFilePickerDemo({ externalUserId }: { externalUserId: string })
     if (items.length > 0) {
       setIsLoadingAction(true);
       setActionResult(null);
-      try {
-        const response = await runAction({
-          id: "sharepoint_admin-retrieve-file-metadata",
-          externalUserId,
-          configuredProps: { ...props, fileIds: buildFileOrFolderIds(items) } as Record<string, unknown>,
-        });
-        setActionResult((response.ret as Record<string, unknown>) ?? { error: "No data returned" });
-      } catch (e) {
-        console.error("Failed to retrieve metadata:", e);
-        setActionResult({ error: e instanceof Error ? e.message : "Unknown error" });
-      } finally {
-        setIsLoadingAction(false);
+      const result = await runAction({
+        id: "sharepoint_admin-retrieve-file-metadata",
+        externalUserId,
+        configuredProps: { ...props, fileIds: buildFileOrFolderIds(items) } as Record<string, unknown>,
+      });
+      if (result.error) {
+        console.error("Failed to retrieve metadata:", result.error);
+        setActionResult({ error: result.error.message });
+      } else {
+        setActionResult((result.data.ret as Record<string, unknown>) ?? { error: "No data returned" });
       }
+      setIsLoadingAction(false);
     } else {
       setActionResult(null);
     }
@@ -408,22 +407,20 @@ function ConfigureFilePickerDemo({ externalUserId }: { externalUserId: string })
     if (!configuredProps || selectedFiles.length === 0) return;
 
     setIsLoadingDownload(true);
-    try {
-      // Map fileOrFolderIds to fileIds for download-files action
-      const { fileOrFolderIds, ...otherProps } = configuredProps;
-      const response = await runAction({
-        id: "sharepoint_admin-download-files",
-        externalUserId,
-        configuredProps: { ...otherProps, fileIds: getFileIds() } as Record<string, unknown>,
-      });
-      const result = (response.ret as Record<string, unknown>) ?? { error: "No data returned" };
-      setDownloadResult(result);
-    } catch (e) {
-      console.error("Failed to run action:", e);
-      setDownloadResult({ error: e instanceof Error ? e.message : "Unknown error" });
-    } finally {
-      setIsLoadingDownload(false);
+    // Map fileOrFolderIds to fileIds for download-files action
+    const { fileOrFolderIds, ...otherProps } = configuredProps;
+    const result = await runAction({
+      id: "sharepoint_admin-download-files",
+      externalUserId,
+      configuredProps: { ...otherProps, fileIds: getFileIds() } as Record<string, unknown>,
+    });
+    if (result.error) {
+      console.error("Failed to run action:", result.error);
+      setDownloadResult({ error: result.error.message });
+    } else {
+      setDownloadResult((result.data.ret as Record<string, unknown>) ?? { error: "No data returned" });
     }
+    setIsLoadingDownload(false);
   };
 
   // Deploy trigger to listen for file changes
@@ -436,30 +433,29 @@ function ConfigureFilePickerDemo({ externalUserId }: { externalUserId: string })
     setIsLoadingTrigger(true);
     setTriggerResult(null);
 
-    try {
-      // Map fileOrFolderIds to fileIds for the trigger
-      const { fileOrFolderIds, ...otherProps } = configuredProps;
+    // Map fileOrFolderIds to fileIds for the trigger
+    const { fileOrFolderIds, ...otherProps } = configuredProps;
 
-      const response = await deployTrigger({
-        id: "sharepoint_admin-updated-file-instant",
-        externalUserId,
-        webhookUrl: webhookUri,
-        configuredProps: { ...otherProps, fileIds: getFileIds() } as Record<string, unknown>,
-      });
+    const result = await deployTrigger({
+      id: "sharepoint_admin-updated-file-instant",
+      externalUserId,
+      webhookUrl: webhookUri,
+      configuredProps: { ...otherProps, fileIds: getFileIds() } as Record<string, unknown>,
+    });
 
+    if (result.error) {
+      console.error("Failed to deploy trigger:", result.error);
+      setTriggerResult({ error: result.error.message });
+    } else {
       setTriggerResult({
         success: true,
         message: "Trigger deployed successfully",
         webhookUri,
         listening: true,
-        response,
+        response: result.data,
       });
-    } catch (e) {
-      console.error("Failed to deploy trigger:", e);
-      setTriggerResult({ error: e instanceof Error ? e.message : "Unknown error" });
-    } finally {
-      setIsLoadingTrigger(false);
     }
+    setIsLoadingTrigger(false);
   };
 
   return (

--- a/connect-react-demo/lib/hooks/use-server-accounts.ts
+++ b/connect-react-demo/lib/hooks/use-server-accounts.ts
@@ -24,20 +24,21 @@ export function useServerAccounts({ externalUserId, app, enabled = true }: Opts)
     const startTime = Date.now()
     const callId = logger?.addCall({ method: "accounts.list", timestamp: new Date(), request, status: "pending" })
 
-    try {
-      const data = await listAccounts(request)
-      setAccounts(data)
-      if (callId) logger?.updateCall(callId, { response: data, status: "success", duration: Date.now() - startTime })
-    } catch (error) {
+    const result = await listAccounts(request)
+
+    if (result.error) {
       setAccounts([])
       if (callId) logger?.updateCall(callId, {
-        error: error instanceof Error ? { message: error.message } : error,
+        error: { message: result.error.message },
         status: "error",
         duration: Date.now() - startTime,
       })
-    } finally {
-      setIsLoading(false)
+    } else {
+      setAccounts(result.data)
+      if (callId) logger?.updateCall(callId, { response: result.data, status: "success", duration: Date.now() - startTime })
     }
+
+    setIsLoading(false)
   }, [externalUserId, app, enabled, logger])
 
   useEffect(() => { refetch() }, [refetch])


### PR DESCRIPTION
## Summary
- Refactor `proxyRequest`, `runAction`, `deployTrigger`, and `listAccounts` in `app/actions/backendClient.ts` to return `{ data, error }` instead of throwing.
- Update callers (`ProxyRequestBuilder`, `DemoPanel`, `file-picker/page`, `use-server-accounts`) to branch on `result.error`.

## Why
Next.js redacts thrown errors from Server Actions in production builds — the client sees a generic "Server Components render" placeholder instead of the real message (e.g. SDK validation errors like "Expected object. Received undefined."). Returned values are passed through unchanged, so this surfaces the real error to the SDK debugger and UI consistently in dev and prod.

## Test plan
- [ ] In production build, trigger a proxy error (e.g. POST with no body) and confirm the real error message appears in the SDK debugger and Error panel.
- [ ] Trigger a successful proxy request and confirm output renders normally.
- [ ] Trigger an action / deploy a trigger with invalid props and confirm the real error message surfaces.
- [ ] file-picker flows: select files, fetch URLs, deploy trigger — all error paths show real messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)