### PR TITLE
Fix tab switching reloading the page in production

### DIFF
--- a/connect-react-demo/lib/use-query-params.tsx
+++ b/connect-react-demo/lib/use-query-params.tsx
@@ -1,13 +1,11 @@
-import { usePathname, useRouter, useSearchParams } from "next/navigation"
-import React, { startTransition } from "react"
+import { useSearchParams } from "next/navigation"
+import React from "react"
 import { z } from "zod"
 import { queryParamSchema } from "./query-params"
 
 type KeyValPair = { key: keyof z.infer<typeof queryParamSchema>, value: string | undefined }
 
 export const useQueryParams = () => {
-  const router = useRouter()
-  const pathname = usePathname()
   const searchParams = useSearchParams()
 
   const setQueryParams = (keyVals: KeyValPair[]) => {
@@ -24,9 +22,11 @@ export const useQueryParams = () => {
     const search = current.toString()
     const query = search ? `?${search}` : ""
 
-    startTransition(() => {
-      router.replace(`${pathname}${query}`, { scroll: false })
-    })
+    // Update URL via history API instead of router.replace. Next.js patches
+    // history.replaceState so useSearchParams stays in sync, and we avoid an
+    // RSC fetch that gets 308-redirected in production (basePath + default
+    // trailingSlash: false) and falls back to a hard reload.
+    window.history.replaceState(null, "", `${window.location.pathname}${query}`)
   }
 
   const setQueryParam = (key: KeyValPair["key"], value: KeyValPair["value"]) => {


### PR DESCRIPTION
## Summary
- In production at `pipedream.com/connect/demo`, clicking the Config/Code/Debug tabs reloaded the page instead of switching tabs. It worked fine locally.
- Root cause: `useQueryParams` used `router.replace(\`${pathname}${query}\`)`. At the root, `usePathname()` returns `/`, so with `basePath: '/connect/demo'` the navigation target became `/connect/demo/?tab=debug`. Next.js (default `trailingSlash: false`) 308-redirects that to the no-trailing-slash form. The Next App Router's RSC fetch hit that 308 and fell back to a hard navigation — the visible "reload". Locally this path doesn't trigger (no prerender, no proxy/CloudFront in front).
- Fix: skip the Next router for query-param-only updates and use `window.history.replaceState` against `window.location.pathname`. Next 14+ patches the history API, so `useSearchParams` stays in sync — no RSC fetch, no 308, no fallback reload.

## Test plan
- [x] Local: tabs still switch and URL still updates with `?tab=code` / `?tab=debug`.
- [x] Local: deep-linking to `?tab=debug` still selects Debug on initial load.
- [x] Local: other query-param-driven state (app, component, propNames, scopeProfile, enableDebugging, etc.) still updates the URL and survives reload.
- [ ] Production (after deploy + CloudFront purge): clicking tabs updates the URL with no document/RSC request in DevTools Network, and the panel content swaps without a visible reload.