### PR TITLE
bump @pipedream/sdk to ^3.1.0

### DIFF
--- a/connect-react-demo/package.json
+++ b/connect-react-demo/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@pipedream/connect-react": "^3.0.1",
-    "@pipedream/sdk": "^3.0.8",
+    "@pipedream/sdk": "^3.1.0",
     "@radix-ui/react-collapsible": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.2",

--- a/connect-react-demo/pnpm-lock.yaml
+++ b/connect-react-demo/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@pipedream/sdk':
-        specifier: ^3.0.8
-        version: 3.0.8
+        specifier: ^3.1.0
+        version: 3.1.0
       '@radix-ui/react-collapsible':
         specifier: ^1.1.1
         version: 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -468,8 +468,8 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@pipedream/sdk@3.0.8':
-    resolution: {integrity: sha512-UzQGqxhkWIhwr2q1sd6HOY99xj+s5vsazbEouu//YzwKSwiWs/KwAKqgGYIEQaBsTUNLpJxlw0XXQl7nG6kdvQ==}
+  '@pipedream/sdk@3.1.0':
+    resolution: {integrity: sha512-qRvrPTqldX60mHKaF0hX/HToqvuH30G58YDQ0/wvFWpc0BcMhUy8bxwGvShSoOnqQwBCxVDaMnO4E6RJy20Xaw==}
     engines: {node: '>=18.0.0'}
 
   '@radix-ui/number@1.1.1':
@@ -2527,7 +2527,7 @@ snapshots:
 
   '@pipedream/connect-react@3.0.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@pipedream/sdk': 3.0.8
+      '@pipedream/sdk': 3.1.0
       '@tanstack/react-query': 5.90.21(react@19.2.4)
       lodash.isequal: 4.5.0
       react: 19.2.4
@@ -2538,7 +2538,7 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@pipedream/sdk@3.0.8': {}
+  '@pipedream/sdk@3.1.0': {}
 
   '@radix-ui/number@1.1.1': {}
 


### PR DESCRIPTION
bump `@pipedream/sdk` to `^3.1.0` to fix async-options not loading due to `POST /v1/connect//components/configure` `404` since `projectId` is always passed as `""` from connect and it is resolved using the connect token being passed.